### PR TITLE
use explicit package paths

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -14,7 +14,7 @@ import (
 	"github.com/unification-com/mainchain/crypto"
 	"github.com/unification-com/mainchain/ethclient"
 
-	store "./contracts"
+	store "github.com/unification-com/oracle/contracts"
 )
 
 const genesis_hash = "GENESIS_STRING"

--- a/oracle.go
+++ b/oracle.go
@@ -15,7 +15,7 @@ import (
 	"github.com/unification-com/mainchain/crypto"
 	"github.com/unification-com/mainchain/ethclient"
 
-	store "./contracts"
+	store "github.com/unification-com/oracle/contracts"
 )
 
 func main() {


### PR DESCRIPTION
This might solve the 

.go/src/github.com/unification-com/oracle/apply.go:17:2: local import \"./contracts\" in non-local package

issue